### PR TITLE
Add back set_epoch functionality lost in RoBERTa merge

### DIFF
--- a/fairseq/data/fairseq_dataset.py
+++ b/fairseq/data/fairseq_dataset.py
@@ -50,3 +50,6 @@ class FairseqDataset(torch.utils.data.Dataset):
     def prefetch(self, indices):
         """Prefetch the data required for this epoch."""
         raise NotImplementedError
+
+    def set_epoch(self, epoch):
+        pass

--- a/fairseq/data/iterators.py
+++ b/fairseq/data/iterators.py
@@ -179,6 +179,7 @@ class EpochBatchIterator(EpochBatchIterating):
             self._cur_epoch_itr = self._get_iterator_for_epoch(
                 self.epoch, shuffle, fix_batches_to_gpus=fix_batches_to_gpus,
             )
+        self.dataset.set_epoch(self.epoch)
         return self._cur_epoch_itr
 
     def end_of_epoch(self) -> bool:


### PR DESCRIPTION
Summary: Pull Request resolved: https://github.com/pytorch/fairseq/pull/982

Differential Revision: D16668353

Pulled By: myleott

fbshipit-source-id: 699243d6c028c47cd0e3f801d89051b3f919b17e